### PR TITLE
Fixed async connection

### DIFF
--- a/amcp_pylib/core/client_async.py
+++ b/amcp_pylib/core/client_async.py
@@ -12,7 +12,8 @@ class ClientAsync(ClientBase):
     
     async def connect(self, host: str = "127.0.0.1", port: int = 5250):
         if not self.connection:
-            self.connection = ConnectionAsync(host, port)
+            self.connection = ConnectionAsync()
+        await self.connection.connect(host, port)
 
     async def send(self, command: Command) -> ResponseBase:
         return await self.send_raw(bytes(command))

--- a/amcp_pylib/core/connection_async.py
+++ b/amcp_pylib/core/connection_async.py
@@ -14,17 +14,9 @@ class ConnectionAsync(ConnectionBase):
     # TCP communication writer
     writer: StreamWriter = None
 
-    def __init__(self, host: str, port: int):
-        # get necessary address information
-        address_info = socket.getaddrinfo(host, port)[0]
-        # create connection from information
-        self.connect(address_info[0], address_info[4])
-
-    async def connect(self, address_family: int, address_target: tuple):
+    async def connect(self, host: str, port: int):
         # create required TCP socket
-        self.reader, self.writer = await open_connection()
-        # connect to provided target
-        await self.connect(address_family, address_target)
+        self.reader, self.writer = await open_connection(host, port)
 
     async def disconnect(self):
         self.writer.close()


### PR DESCRIPTION
Hi,

I don't understand how the async client could have ever worked, `ConnectionAsync.connect` was an infinite loop and you cant have an async `__init__`

This change should fix that.

Thanks,