### PR TITLE
Treat command  arguments with a None value as if they weren't specified

### DIFF
--- a/amcp_pylib/core/command.py
+++ b/amcp_pylib/core/command.py
@@ -28,6 +28,10 @@ def command_syntax(syntax_rules: str):
                     # get provided argument value
                     arg_value = kwargs[arg_name]
 
+                    # Treat arguments with a None value as if they weren't specified
+                    if arg_value is None:
+                        continue
+
                     # try to convert dict and list values to JSON
                     if isinstance(arg_value, dict) or isinstance(arg_value, list):
                         arg_value = json.dumps(arg_value)


### PR DESCRIPTION
Hi,

These changes introduce the ability to ignore command arguments if their value is None.

This is useful for example for the `loop` argument of the `basic.PLAY` command which **only** accepts the value `LOOP` if specified.
Without this, it would require creating a different command based on if loop is present or not.
With this change, it can be used like so:
```python
basic.PLAY(
    video_channel=1,
    layer=10,
    clip="TEST",
    loop="LOOP" if some_boolean_indicating_if_it_should_loop else None
)
```

I'm not too familiar with the rest of the library so I'm unsure if this affects something else down the road, please let know!

Thanks!

